### PR TITLE
Add some COVID-19 notices in key places

### DIFF
--- a/_pages/calendar.md
+++ b/_pages/calendar.md
@@ -3,6 +3,11 @@
     title: Calendar
 ---
 
+<div class="alert alert-warning">
+  In accordance with <a href="http://web.mit.edu/covid19/">MIT's response to COVID-19</a>,
+  <strong>all MITOC office hours are canceled indefinitely.</strong>
+</div>
+
 A great way to stay informed is to check our Google calendar. This calendar has our events, office hours, and cabin reservations.
 
 Add the MITOC calendar to your Google calendar by pressing ![Google calendar logo](/images/calendar/googleplus.png) (lower right corner of the calendar.)

--- a/_pages/join.md
+++ b/_pages/join.md
@@ -4,6 +4,11 @@
     subtitle: It's easy to become a member, and anyone can join.
 ---
 
+<div class="alert alert-warning">
+  In accordance with <a href="http://web.mit.edu/covid19/">MIT's response to COVID-19</a>,
+  <strong>all MITOC events are canceled indefinitely.</strong>
+</div>
+
 ### 1. (Optional) Join [MITOC mailing lists](/mailing-lists)
 
 Mailing lists are our primary way to announce upcoming events and organize informal trips. You do _not_ have to pay the membership fee to join mailing lists, and paying the fee will _not_ automatically sign you up for any mailing lists!

--- a/_pages/rentals/index.md
+++ b/_pages/rentals/index.md
@@ -9,6 +9,11 @@
       - /images/rental/pic4.jpg
 ---
 
+<div class="alert alert-warning">
+  In accordance with <a href="http://web.mit.edu/covid19/">MIT's response to COVID-19</a>,
+  <strong>all MITOC office hours are canceled indefinitely.</strong>
+</div>
+
 **Please read this whole page before coming in to rent gear for the first time.** There is some administrativia involved, and planning ahead will help your rental go smoothly.
 
 ## How to Rent Gear


### PR DESCRIPTION
We want to ensure that MITOC members do not:

1. Pay membership dues unnecessarily (since we have no events at
   present, nor do we support gear rental)
2. Expect office hours to be running


We might want to add more notices elsewhere, but this adds some simple warnings.
A similar warning was added to key pages on https://github.com/DavidCain/mitoc-trips/commit/03455a079855094f269f3499adf3f90757795ffc