### PR TITLE
Add rooms page for WS 2021

### DIFF
--- a/_pages/rooms.md
+++ b/_pages/rooms.md
@@ -3,7 +3,7 @@
     title: Winter School 2021 - group discussions rooms
     rooms:
       - title: "Winter Hiking: How to Start"
-        link:
+        link: https://mit.zoom.us/j/94450959676
       - title: "Winter Hiking: Above Treelines"
         link:
       - title: Winter Camping
@@ -15,7 +15,7 @@
       - title: Human Metabolism! Layering and Heat Management in the Winter (and Summer!)
         link:
       - title: Women in the Outdoors (Open to all who identify as women or non-binary)
-        link:
+        link: https://mit.zoom.us/j/91023986078
 ---
 
 {% for room in page.rooms%}

--- a/_pages/rooms.md
+++ b/_pages/rooms.md
@@ -1,0 +1,23 @@
+---
+    permalink: /rooms
+    title: Winter School 2021 - group discussions rooms
+    rooms:
+      - title: "Winter Hiking: How to Start"
+        link:
+      - title: "Winter Hiking: Above Treelines"
+        link:
+      - title: Winter Camping
+        link:
+      - title: The Joy of Ice Climbing
+        link:
+      - title: Enjoying Winter
+        link:
+      - title: Human Metabolism! Layering and Heat Management in the Winter (and Summer!)
+        link:
+      - title: Women in the Outdoors (Open to all who identify as women or non-binary)
+        link:
+---
+
+{% for room in page.rooms%}
+- [**{{room.title}}** - {{room.link}}]({{room.link}})
+{% endfor %}


### PR DESCRIPTION
Adding the temporary page so that we can easily send WS attendees to the zoom room of their choice. 

I'll add the URL on Thursday evening before the lecture starts. 