### PR TITLE
Fix leader images

### DIFF
--- a/js/mitoc.js
+++ b/js/mitoc.js
@@ -1,14 +1,6 @@
 ---
 ---
 
-//Helper function to see if a URL returns a 404
-function urlExists(url){
-    var http = new XMLHttpRequest();
-    http.open('HEAD', url, false);
-    http.send();
-    return http.status!=404;
-}
-
 //Load leader lists from mitoc-trips.mit.edu and populate the table
 function loadLeadersFromTripsWebsite(activityId, divId) {
     $.getJSON('https://mitoc-trips.mit.edu/leaders.json/' + activityId, function(data) {
@@ -17,14 +9,10 @@ function loadLeadersFromTripsWebsite(activityId, divId) {
         var leaders = data.leaders;
         var l = leaders.length;
         for(var i = 0; i < l; i++) {
-		    // Try to get the user's Gravatar; otherwise, use the beaver as a fallback
+		    // Try to get the user's Gravatar; otherwise, use the beaver as a fallback rather than the Gravatar fallback
             var gravUrl = new URL(leaders[i].gravatar);
-            gravUrl.searchParams.set("d", "404"); // return a 404 if not found
-            if(urlExists(gravUrl)){
-                leaders[i].gravatar = gravUrl;
-            } else {
-                leaders[i].gravatar = 'https://mitoc.mit.edu/images/leaders/Beaver.jpg';
-            }
+            gravUrl.searchParams.set("d", "https://mitoc.mit.edu/images/leaders/Beaver.jpg");
+            leaders[i].gravatar = gravUrl.href;
 
             leaderListEntries = leaderListEntries
                     + '<div class="col-lg-2 col-md-3 col-sm-4 col-xs-6"><img height="100" width="100" src="'

--- a/js/mitoc.js
+++ b/js/mitoc.js
@@ -1,6 +1,14 @@
 ---
 ---
 
+//Helper function to see if a URL returns a 404
+function urlExists(url){
+    var http = new XMLHttpRequest();
+    http.open('HEAD', url, false);
+    http.send();
+    return http.status!=404;
+}
+
 //Load leader lists from mitoc-trips.mit.edu and populate the table
 function loadLeadersFromTripsWebsite(activityId, divId) {
     $.getJSON('https://mitoc-trips.mit.edu/leaders.json/' + activityId, function(data) {
@@ -9,8 +17,15 @@ function loadLeadersFromTripsWebsite(activityId, divId) {
         var leaders = data.leaders;
         var l = leaders.length;
         for(var i = 0; i < l; i++) {
-		    //Use the cute beaver instead of the Gravatar default pic
-			leaders[i].gravatar = leaders[i].gravatar.substr(0, leaders[i].gravatar.length - 2) + 'http%3A%2F%2Fmitoc.mit.edu%2Fimages%2Fleaders%2Fbeaver.jpg';
+		    // Try to get the user's Gravatar; otherwise, use the beaver as a fallback
+            var gravUrl = new URL(leaders[i].gravatar);
+            gravUrl.searchParams.set("d", "404"); // return a 404 if not found
+            if(urlExists(gravUrl)){
+                leaders[i].gravatar = gravUrl;
+            } else {
+                leaders[i].gravatar = 'https://mitoc.mit.edu/images/leaders/Beaver.jpg';
+            }
+
             leaderListEntries = leaderListEntries
                     + '<div class="col-lg-2 col-md-3 col-sm-4 col-xs-6"><img height="100" width="100" src="'
                     + leaders[i].gravatar + '">'


### PR DESCRIPTION
Currently, the [climbing leaders](https://mitoc.mit.edu/get-involved/become-climbing-leader), [paddling leaders](https://mitoc.mit.edu/get-involved/become-paddling-leader), and [winter school leaders](https://mitoc.mit.edu/get-involved/become-ws-leader) pages use `mitoc.js` to grab gravitar images, but it's not working. This correctly uses the gravitar url and sets the default to the beaver.