### PR TITLE
Add fees for the self-rescue course

### DIFF
--- a/_data/trip_fees.yml
+++ b/_data/trip_fees.yml
@@ -71,6 +71,14 @@
     price: 15
     category: trip
 -
+    name: "Self-rescue course (full): $225"
+    price: 225
+    category: trip
+-
+    name: "Self-rescue course (subsidized): $125"
+    price: 125
+    category: trip
+-
     name: "Ski-a-Palooza $10"
     price: 10
     category: trip


### PR DESCRIPTION
Per request of Paul Lilin, this adds line items for paying the trip fees
from the rock climbing self-rescue course, open for signups at
https://mitoc-trips.mit.edu/trips/1402/