### PR TITLE
Remove leaders list from website

### DIFF
--- a/_includes/leaders.html
+++ b/_includes/leaders.html
@@ -1,6 +1,0 @@
-<div id="{{ include.id }}" class="row is-flex"></div>
-<script>
-    window.addEventListener('DOMContentLoaded', function() {
-      loadLeadersFromTripsWebsite('{{ include.activity }}', "#{{ include.id }}");;
-    });
-</script>

--- a/_pages/get-involved/become-climbing-leader.md
+++ b/_pages/get-involved/become-climbing-leader.md
@@ -41,10 +41,3 @@ The best way to learn all the skills necessary is to co-lead some trips with lea
 ### Questions?
 
 Contact [climbing-chair@mit.edu](mailto:climbing-chair@mit.edu)
-
-### Climbing Leaders
-
-{% include leaders.html activity='climbing' id='climbing-leaders-list' %}
-
-
-

--- a/_pages/get-involved/become-paddling-leader.md
+++ b/_pages/get-involved/become-paddling-leader.md
@@ -34,8 +34,3 @@ Please fill out [this form](https://docs.google.com/spreadsheet/embeddedform?for
 ### I want to become a leader but I'm not ready yet.
 
 The MITOC paddling community offers a wide array of trips, sessions, and socials throughout the year. These are announced via email on the paddle list and on the MITOC trip sign-up page. The best way to develop your paddling skills and gain confidence as a prospective leader is to get involved! We’re here to help so let us know if you're interested!
-
-### Current Paddling Leaders
-
-{% include leaders.html activity='boating' id='paddle-leaders' %}
-

--- a/_pages/get-involved/become-ws-leader.md
+++ b/_pages/get-involved/become-ws-leader.md
@@ -61,7 +61,3 @@ Any prospective leader is also strongly encouraged to become a keyholder for one
 ### Questions?
 
 Contact [ws-chair@mit.edu](mailto:ws-chair@mit.edu)
-
-### Current Winter School Leaders
-
-{% include leaders.html activity='winter_school' id='ws-leaders' %}

--- a/_pages/rentals/boathouse.md
+++ b/_pages/rentals/boathouse.md
@@ -128,8 +128,3 @@ If you've never done this before, read on for...
 Approver is the Surfing chair for the appropriate gear ([boathouse-mgr@mit.edu](mailto:boathouse-mgr@mit.edu))
 
 {% include price-table.html category = site.data.gear_prices.surfing %}
-
-
-### Paddling Leaders
-
-{% include leaders.html activity='boating' id='paddle-leaders' %}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,9 @@
-version: '2.4'
+version: "2.4"
 
 services:
   jekyll:
-    image: bretfisher/jekyll-serve
+    image: bretfisher/jekyll-serve:gha-3065492800
     volumes:
       - .:/site
     ports:
-      - '4000:4000'
+      - "4000:4000"

--- a/js/mitoc.js
+++ b/js/mitoc.js
@@ -1,29 +1,6 @@
 ---
 ---
 
-//Load leader lists from mitoc-trips.mit.edu and populate the table
-function loadLeadersFromTripsWebsite(activityId, divId) {
-    $.getJSON('https://mitoc-trips.mit.edu/leaders.json/' + activityId, function(data) {
-        //Format the data into HTML
-        var leaderListEntries = '';
-        var leaders = data.leaders;
-        var l = leaders.length;
-        for(var i = 0; i < l; i++) {
-		    // Try to get the user's Gravatar; otherwise, use the beaver as a fallback rather than the Gravatar fallback
-            var gravUrl = new URL(leaders[i].gravatar);
-            gravUrl.searchParams.set("d", "https://mitoc.mit.edu/images/leaders/Beaver.jpg");
-            leaders[i].gravatar = gravUrl.href;
-
-            leaderListEntries = leaderListEntries
-                    + '<div class="col-lg-2 col-md-3 col-sm-4 col-xs-6"><img height="100" width="100" src="'
-                    + leaders[i].gravatar + '">'
-                    + leaders[i].name + '</div>\n';
-        }
-        //Write into div with id=divId
-        $(divId).html(leaderListEntries);
-    });
-}
-
 //Load trip fee schedule from Google Sheets on the payment page
 function load_trip_fees() {
     //Populate dropdown menu and list of prices


### PR DESCRIPTION
The mitoc-trips endpoint used to render the leaders list has been deprecated and removed a while ago. 
Remove these lists all-together, since we don't think they were particularly useful. 