### PR TITLE
Update climbing gear rental price list

### DIFF
--- a/_data/gear_prices.yml
+++ b/_data/gear_prices.yml
@@ -45,6 +45,9 @@ climbing:
     - title: ATC and Locking Biner
       deposit: $30
       rental: $2
+    - title: Grigri and Locking Biner
+      deposit: $100
+      rental: $3
     - title: Climbing Shoes
       deposit: $60
       rental: $5
@@ -54,25 +57,44 @@ climbing:
     - title: Climbing Harness
       deposit: $60
       rental: $4
-    - title: Plastic Boot
-      deposit: $200
-      rental: $6
+    - title: Stick Clip
+      deposit: $50
+      rental: $5
   restricted_items:
+    # Bouldering
     - title: Bouldering Pad
       deposit: $200
-      rental: $5
-    - title: Ascenders, Daisies, and Ladders
-      deposit: $250
-      rental: $5
+      rental: $6
+    # Sport
     - title: Quickdraws (pack of 6)
       deposit: $80
       rental: $5
     - title: Ohm Assisted Braking Device
       deposit: $100
+      rental: $2
+    # Trad
+    - title: Single rack (.2-3 Camalot, BD offset nuts)
+      deposit: $500
+      rental: $10
+    - title: C4 #4/5/6/7/8
+      deposit: $60/80/100/140/140
+      rental: $4
+    - title: Microtraxion
+      deposit: $100
+      rental: $3
+    # Aid / Big walls
+    - title: Ascenders, Daisies, and Ladders
+      deposit: $250
       rental: $5
     - title: Haul Bag
       deposit: $140
       rental: $5
+    - title: G7 Pod Portaledge (1p)
+      deposit: $785
+      rental: $10
+    - title: G7 Alpine Shelter
+      deposit: $450
+      rental: $8
 
 winter_hiking:
   items:

--- a/_data/gear_prices.yml
+++ b/_data/gear_prices.yml
@@ -76,8 +76,8 @@ climbing:
     - title: Single rack (.2-3 Camalot, BD offset nuts)
       deposit: $500
       rental: $10
-    - title: C4 \#4/5/6/7/8
-      deposit: $60/80/100/140/140
+    - title: "Large cams, #4-8 Camalot (individual)"
+      deposit: $60-140
       rental: $4
     - title: Microtraxion
       deposit: $100

--- a/_data/gear_prices.yml
+++ b/_data/gear_prices.yml
@@ -76,7 +76,7 @@ climbing:
     - title: Single rack (.2-3 Camalot, BD offset nuts)
       deposit: $500
       rental: $10
-    - title: C4 #4/5/6/7/8
+    - title: C4 \#4/5/6/7/8
       deposit: $60/80/100/140/140
       rental: $4
     - title: Microtraxion


### PR DESCRIPTION
Updated the climbing gear list to include missing items and adjust some rental prices.

(also removed plastic boots from climbing, they are listed under winter already. if this is misguided and there are separate types of plastic boots, can add back.)

Will update the gear db to reflect a few price changes:
- ohm $5 -> $2 (is safety gear, should encourage use)
- single rack $5 -> $10
- portaledge $5 -> $10
- portaledge fly $5 -> $8
- grigri $5 -> $3
- crash pads $5 -> $6
- all big cams $5 -> $4