### PR TITLE
Update trip_fees.yml

### DIFF
--- a/_data/trip_fees.yml
+++ b/_data/trip_fees.yml
@@ -19,6 +19,12 @@
 - name: "Circus (Non-Student): $40"
   price: 40
   category: trip
+- name: "Circus (misc): $10"
+  price: 10
+  category: trip
+- name: "Circus (misc): $30"
+  price: 30
+  category: trip
 - name: "Intervale exclusive rental: $250"
   price: 250
   category: cabin


### PR DESCRIPTION
Sorry! I was too hasty in my previous PR. I forgot that we give folks the option to pay $10 less if they lead and or drive so we actually end up with 4 tiers still [student + discount, student, non-student + discount, non-student]. 

I just noted them as "(misc)", since I was worried "(Student + driver/leader discount)" would be too long for the dropdown. But if you think that'll fit fine or have another wording suggestion happy to change it!