### PR TITLE
Remove COVID notices from 2023

### DIFF
--- a/_pages/rentals/index.md
+++ b/_pages/rentals/index.md
@@ -8,13 +8,7 @@
       - /images/rental/pic3.jpg
       - /images/rental/pic4.jpg
 ---
-<div class="alert alert-success"> 
-<p><strong>Stratton Student Center Closure (Updated November 2023): The student center and gear office are open again! We are resuming office hours out of the MITOC office located in the stratton student center, W20 461. Check the <a href="https://mitoc.mit.edu/calendar">calendar</a> for office hour times and staffing.</strong></p>
-</div>
 
-<div class="alert alert-warning"> 
-<p><strong>COVID Access Update (Jan 2023): You must comply with <a href="http://web.mit.edu/covid19/">MIT's COVID-19 policies</a> to visit MIT's campus.</strong></p>
-</div>
 
 **Please read this whole page before coming in to rent gear for the first time.** There is some administrativia involved, and planning ahead will help your rental go smoothly.
 
@@ -26,22 +20,22 @@
 1.  **Make sure you are a [current MITOC member](/join).** Membership dues are good for one year.
 2.  **Make sure your [liability waiver](/join) is up to date.** To rent gear or go on official MITOC trips, you must electronically sign a liability waiver, which is valid for one year.
 3.  **Get approval if renting restricted gear.**
-    
+
     Certain climbing and watersports items require a safety review and permission from the appropriate MITOC officer before you can rent them. These items are highlighted red in the [price list](/rentals/prices).
-    
+
     You can get approval by emailing the address listed next to the gear 24 hours ahead of time. Be sure to include exactly what restricted gear you want to check out, what dates you'll have it, how and where it will be used, and your level of experience with the activity.
-    
+
 
 ### Renting Gear
 
 1.  **Bring your checkbook.** We will ask for a check as collateral for your rental. It will not be cashed unless you fail to return gear after 10 weeks and we can't contact you after three attempts. You have two options:
-    
+
     1.  One-time deposit check: You write one check for the value of the gear you rent. It is destroyed when you return the gear.
     2.  Frequent flyer check: You write two checks for $700 and $300. They are kept on file for one year, and you can rent as often as you like without writing more checks.
-    
+
     Deposit checks are mandatory and must be _personal checks_. NO EXCEPTIONS UNDER ANY CIRCUMSTANCES. We will not accept money orders, cashier's checks, cash, credit cards, IDs, valuables, or anything else as collateral for rentals. Do not try to pressure deskworkers to bend this rule.
-    
-2.  **Come by the [MITOC office (Student center, 4th floor, room 461)](http://whereis.mit.edu/?go=W20) during office hours.** Office hours can be found on our [calendar](/calendar) and are usually Tuesday and Thursday evenings and ocasionally Friday afternoons. Check the calendar to make sure a volunteer desk worker has signed up before coming in to the office. An event titled "Office Hours" without names appended to it means that nobody has signed up for that shift yet (note that shifts are usually staffed a few days beforehand, it's perfectly normal for future shifts to not have a name alongside them).
+
+2.  **Come by the [MITOC office (Student center, 4th floor, room 461)](https://whereis.mit.edu/?go=W20) during office hours.** Office hours can be found on our [calendar](/calendar) and are usually Tuesday and Thursday evenings and ocasionally Friday afternoons. Check the calendar to make sure a volunteer desk worker has signed up before coming in to the office. An event titled "Office Hours" without names appended to it means that nobody has signed up for that shift yet (note that shifts are usually staffed a few days beforehand, it's perfectly normal for future shifts to not have a name alongside them).
 3.  **Go outside and have fun! Yay!**
 
 ### Returning Gear
@@ -49,11 +43,11 @@
 1.  **Make sure everything is clean and dry.** We will not accept returns of wet tents, boots, sleeping bags, etc.
 2.  **Come to [office hours](/calendar) and return gear.**
 3.  **Pay for your rental.**
-    
+
     We accept two modes of payment: credit/debit card (preferred) or check. When paying by credit card, make sure to bring a laptop or smartphone with you to office hours.
-    
+
     We charge per day that you use the gear. For example, if you rent a tent during Thursday office hours, use it on Friday and Saturday, and return it the following Wednesday, we will charge for two days of use. There is a minimum charge of one day's use per weekend that you have gear checked out.
-    
+
 
 * * *
 
@@ -128,7 +122,7 @@ We provide this service as a convenience to MITOCers whose schedule may not perm
 
 #### Can I leave rental returns outside of the office door?
 
-Absolutely not. Gear is not considered returned until it has been secured inside the office and returned through the gear database. If gear left outside the office is lost, the renter of record will be charged for the full amount of the deposit. If you cannot make it yourself, try to get a friend to return your gear for you during office hours. In extraordinary circumstances (illness, etc) please contact [mitoc-desk@mit.edu](mailto:mitoc-desk@mit.edu). 
+Absolutely not. Gear is not considered returned until it has been secured inside the office and returned through the gear database. If gear left outside the office is lost, the renter of record will be charged for the full amount of the deposit. If you cannot make it yourself, try to get a friend to return your gear for you during office hours. In extraordinary circumstances (illness, etc) please contact [mitoc-desk@mit.edu](mailto:mitoc-desk@mit.edu).
 </div>
 
 <div class="well" markdown="1">


### PR DESCRIPTION
The link to MIT's COVID policies redirects to https://covid19.mit.edu/,
which doesn't even resolve. The Student Center has been open normally
for years now, we no longer need to take up valuable real estate on one
of our most-read pages!