### PR TITLE
Correct activity chairs

### DIFF
--- a/_data/positions.yml
+++ b/_data/positions.yml
@@ -162,7 +162,7 @@
     - title: Canoe Chair
       description: Leads canoeing trips; maintains canoe fleet
       officers:
-        - LorenzoShaikewitz
+        - LaurelCiccaglione
         - EvanKindseth
     - title: Biking Chair
       description: Leads biking trips; maintains bikes


### PR DESCRIPTION
This updates current BOD (last posted on April 11) so as to match the "2025 MITOC Election Table"

Laurel & Evan are the canoe chairs (Lorenzo & Evan are whitewater chairs!)

I spot-checked all other positions, they seem correct.