### PR TITLE
Update leader coordinator position description and fill vacancy.

### DIFF
--- a/_data/officers.yml
+++ b/_data/officers.yml
@@ -116,6 +116,8 @@ CristianCavedon:
 DanielYang:
   name: "Daniel Yang"
   photo: DanielYang.png
+DavidCharatan:
+  name: "David Charatan"
 DavidJohnson:
   name: "David Johnson"
   photo: johnson_.png

--- a/_data/positions.yml
+++ b/_data/positions.yml
@@ -65,9 +65,9 @@
         - CarolinaWarneryd
         - BenMoody
     - title: Leader Coordinator
-      description: Manages course subsidies and other incentives for trip leaders
+      description: Manages Winter School gear orders and other incentives for trip leaders
       officers:
-        - Vacant
+        - DavidCharatan
     - title: Webmaster
       description: Maintains club website and databases
       officers:

--- a/_pages/about/get-reimbursed.md
+++ b/_pages/about/get-reimbursed.md
@@ -30,7 +30,7 @@ Questions? Contact [mitoc-trez@mit.edu](mailto:mitoc-trez@mit.edu).
 
   Pay the course cost in full (to the provider, not MITOC).
   
-  For a subsity, email both the leader coordinator and [mitoc-trez@mit.edu](mailto:mitoc-trez@mit.edu) listing the course you will be reimbursed for & links to the led trips being used for the subsity. Then follow the directions on this page for "Other non-travel" that applies to you.
+  For a subsity, email [mitoc-trez@mit.edu](mailto:mitoc-trez@mit.edu) listing the course you will be reimbursed for & links to the led trips being used for the subsity. Then follow the directions on this page for "Other non-travel" that applies to you.
 
   For desk credit 'payment', the treasurer will reimburse you for the specified amount in the google form. Follow the directions on this page for "Other non-travel" that applies to you.
 


### PR DESCRIPTION
This PR updates the "Get Reimbursed" page's instructions to no longer say that the leader coordinator should be emailed when requesting course subsidies. As Hannah (@hmsch) points out, the leader coordinator is not actually involved in managing subsidies, since the course coordinator checks attendance and the treasurer then processes the corresponding subsidies. This PR also updates the leader coordinator's description on the website to more accurately reflect the role's current responsibilities and fills the vacancy.