### PR TITLE
Update BOD positions on website.

### DIFF
--- a/_data/officers.yml
+++ b/_data/officers.yml
@@ -1,6 +1,8 @@
 ---
 AalokSathe:
   name: "Aalok Sathe"
+AaronJohnson:
+  name: "Aaron Johnson"
 AbbyHill:
   name: "Abby Hill"
   photo: abbyhill.jpg
@@ -237,6 +239,8 @@ LucasArthur:
 LucasEhinger:
   name: "Lucas Ehinger"
   photo: LucasEhinger.jpg
+LucyNguyen:
+  name: "Lucy Nguyen"
 LukePlummer:
   name: "Luke Plummer"
   photo: lukeplummer.jpg
@@ -314,6 +318,8 @@ PaulNicknish:
 PavelGorelik:
   name: "Pavel Gorelik"
   photo: pavel.jpg
+RebeccaKestin:
+  name: "Rebecca Kestin"
 RikaSugimoto:
   name: Rika Sugimoto Dimitrova
   photo: rika.jpeg

--- a/_data/positions.yml
+++ b/_data/positions.yml
@@ -100,8 +100,7 @@
     - title: Winter School Chair
       description: Organizes annual Winter School
       officers:
-        - AshutoshKumar
-        - JoePalin
+        - Vacant
       email: ws-chair@mit.edu
     - title: Circus Chair
       description: Organizes monthly Circus (April to October)
@@ -113,7 +112,8 @@
     - title: Social Chair
       description: Organizes monthly social events
       officers:
-        - Vacant
+        - AaronJohnson
+        - RebeccaKestin
     - title: Acadia Chair
       description: Organizes yearly Acadia trip
       officers:
@@ -128,7 +128,6 @@
       description: Recruits, trains, and approves climbing leaders; organizes School of Rock, climbing courses, and technical review sessions
       officers:
         - KathyCamenzind
-        - AshaParkCarter
         - JolienVanNieuwenhuizen
         - FlorianPagnoux
     - title: Backcountry Skiing Chair
@@ -203,5 +202,5 @@
     - title: Mediation Chair
       description: Leads committee that resolves conflicts
       officers:
-        - MikeChan
+        - LucyNguyen
         - CarolinaWarneryd


### PR DESCRIPTION
This PR updates the BOD positions on the website using [this document](https://docs.google.com/document/d/1YLxLS3KDqUfg0kDU46UJfbI8o9qN5MKM66PArzT32t8/edit?usp=sharing) as a source of truth (I needed the BOD positions for leader coordinator tasks, and after some discussion with @dxyang, I figured it would be good to update the website).