### PR TITLE
Reflect climbing chair changeover

### DIFF
--- a/_data/positions.yml
+++ b/_data/positions.yml
@@ -130,7 +130,6 @@
         - KathyCamenzind
         - JolienVanNieuwenhuizen
         - FlorianPagnoux
-        - AshaParkCarter
     - title: Backcountry Skiing Chair
       description: Recruits winter leaders for backcountry skiing; maintains backcountry skiing gear
       officers:


### PR DESCRIPTION
This reverts commit 0938416fee189c6e81a27a6de8c6d6ebeddbb61c.

Effective July 1, climbing chairs are those elected in the most recent BOD election.