### PR TITLE
Fix naming and remove unused trip fee entry

### DIFF
--- a/_data/trip_fees.yml
+++ b/_data/trip_fees.yml
@@ -7,13 +7,13 @@
 - name: "Acadia - non-affiliate: $60"
   price: 60
   category: trip
-- name: "Climbers' Open Cabin - camping: $13"
+- name: "Climbers Open Cabin - camping: $13"
   price: 13
   category: trip
-- name: "Climbers' Open Cabin - sleeping inside: $18"
+- name: "Climbers Open Cabin - sleeping inside: $18"
   price: 18
   category: trip
-- name: "Climbers' Open Cabin - food only: $8"
+- name: "Climbers Open Cabin - food only: $8"
   price: 8
   category: trip
 - name: "Paddleboarding Trip: $15"
@@ -72,9 +72,6 @@
   category: trip
 - name: "Sport climbing trip fee: $10"
   price: 10
-  category: trip
-- name: "Climbers Cabin Night (Food) - $8"
-  price: 8
   category: trip
 - name: "Ice climbing trip fee: $30"
   price: 30


### PR DESCRIPTION
Removed apostrophes from 'Climbers' Open Cabin' entries and deleted 'Climbers Cabin Night (Food)' entry.