### PR TITLE
Bump bunkhouse estimated completion date from 2025 to 2027

### DIFF
--- a/_includes/camelot_banner.html
+++ b/_includes/camelot_banner.html
@@ -29,9 +29,9 @@
 
         <p>
           With the design now complete, we are actively seeking donations. If you
-          are able, please consider donating to help us hit our fundraising target
-          in 2025. We broke ground on site preparation in 2024, and
-          fundraising permitting, we will complete the new bunkhouse in 2025.
+          are able, please consider donating to help us hit our fundraising target.
+          We broke ground on site preparation in 2024, and
+          fundraising permitting, we will complete the new bunkhouse in 2027.
           This project will ensure we can fulfill our mission for the next
           generation of MITOCers.
         </p>

--- a/_pages/camelot/faqs.md
+++ b/_pages/camelot/faqs.md
@@ -59,7 +59,7 @@ Yes, it is possible to donate by check!  Please make your check payable to MIT F
 
 ### When will construction start?
 
-We signed the contract for site preparation, including construction of the new parking lot and access trail, in December 2023. This construction started in summer 2024 and will wrap up in spring 2025. For the next phase, more funding is needed. Funding permitting, the bunkhouse structure itself will be erected starting in 2026 or 2027.
+We signed the contract for site preparation, including construction of the new parking lot and access trail, in December 2023. This construction started in summer 2024 and will wrap up in spring 2025. For the next phase, more funding is needed. Funding permitting, the bunkhouse structure itself will be erected starting in summer 2027.
 
 ### How long will construction take?
 

--- a/_pages/camelot/faqs.md
+++ b/_pages/camelot/faqs.md
@@ -59,11 +59,11 @@ Yes, it is possible to donate by check!  Please make your check payable to MIT F
 
 ### When will construction start?
 
-We signed the contract for site preparation, including construction of the new parking lot and access trail, in December 2023. This construction started in summer 2024 and will wrap up in spring 2025.  Funding permitting, the bunkhouse structure itself will be erected starting in summer 2025.
+We signed the contract for site preparation, including construction of the new parking lot and access trail, in December 2023. This construction started in summer 2024 and will wrap up in spring 2025. For the next phase, more funding is needed. Funding permitting, the bunkhouse structure itself will be erected starting in 2026 or 2027.
 
 ### How long will construction take?
 
-Construction of the bunkhouse will take about six months, but needs to be paused for winter weather.  In the best case, the bunkhouse could be finished in 2025.  If fundraising proceeds more slowly, construction would slip into 2026.
+Construction of the bunkhouse will take about six months, but needs to be paused for winter weather. Funding permitting, the bunkhouse could be finished in 2027. 
 
 ### Will the bunkhouse be heated?
   

--- a/_pages/camelot/faqs.md
+++ b/_pages/camelot/faqs.md
@@ -59,7 +59,7 @@ Yes, it is possible to donate by check!  Please make your check payable to MIT F
 
 ### When will construction start?
 
-We signed the contract for site preparation, including construction of the new parking lot and access trail, in December 2023. This construction started in summer 2024 and will wrap up in spring 2025. For the next phase, more funding is needed. Funding permitting, the bunkhouse structure itself will be erected starting in summer 2027.
+We signed the contract for site preparation, including construction of the new parking lot and access trail, in December 2023. This construction started in summer 2024 and wrapped  in spring 2025. For the next phase, more funding is needed. Funding permitting, the bunkhouse structure itself will be erected starting in summer 2027.
 
 ### How long will construction take?
 


### PR DESCRIPTION
The current completion date of 2025 is in the past. Probably more of the bunkhouse pages need updating, but I don't know the details. Since the banner is shown to everyone visiting our site, I think we should edit that number at least.

I asked dlaw about an update on the timeline and it sounds like it would be 1.5-2 more years after we get 2-3 more volunteers to work on fundraising. So it's not clear whether completion in 2027 would be feasible but that's our earliest guess.