### PR TITLE
Revert circus fees to $40/$20 until BOD discussion

### DIFF
--- a/_data/trip_fees.yml
+++ b/_data/trip_fees.yml
@@ -19,22 +19,16 @@
 - name: "Canoe Trip: $15"
   price: 15
   category: trip
-- name: "Circus (Student): $15"
-  price: 15
-  category: trip
-- name: "Circus (Non-Student): $25"
-  price: 25
-  category: trip
-- name: "Circus (Discounted Option 1): $5"
-  price: 5
-  category: trip
-- name: "Circus (Discounted Option 2): $10"
-  price: 10
-  category: trip
-- name: "Circus (Discounted Option 3): $20"
+- name: "Circus (Student): $20"
   price: 20
   category: trip
-- name: "Circus (Misc): $30"
+- name: "Circus (Non-Student): $40"
+  price: 40
+  category: trip
+- name: "Circus (Student discounted): $10"
+  price: 10
+  category: trip
+- name: "Circus (Non-Student discounted): $30"
   price: 30
   category: trip
 - name: "Intervale exclusive rental: $250"


### PR DESCRIPTION
Circus trip fees are scheduled for discussion at the July BoD meeting following the recent food budget increase. Reverting to the standard $40/$20 fees until an updated fee structure has been proposed and voted on to avoid confusing participants. 
(Should remember to also update https://mitoc.mit.edu/events/circus once the new fees are finalized.)